### PR TITLE
Add hook to check for OrderedDict usage

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,9 @@
     entry: eos-test-check-argument-order
     language: python
     types: [text]
+-   id: eos-test-ordereddict-usage
+    name: 'EOS: OrderedDict usage'
+    description: Checks if OrderedDict is imported, as it likely isn't needed
+    entry: eos-test-ordereddict-usage
+    language: python
+    types: [text]

--- a/eos_pre_commit_hooks/eos_test_ordereddict_usage.py
+++ b/eos_pre_commit_hooks/eos_test_ordereddict_usage.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import re
+import subprocess
+from typing import Sequence
+
+def eos_test_ordereddict_usage(
+        filenames: Sequence[str],
+        *,
+        enforce_all: bool = False,
+) -> int:
+    # Find all .py files that are also in the list of files pre-commit tells
+    # us about
+    retv = 0
+    filenames_filtered = set(filenames)
+
+    checks = [ re.compile(r'^import collections.OrderedDict'),
+               re.compile(r'^from collections import .*OrderedDict'),
+    ]
+    msg = 'Since Python 3.7, the regular dict class is guaranteed to preserve insertion order so OrderedDict (likely) is not needed'
+
+    for filename in filenames_filtered:
+        if not filename.endswith('.py'):
+            pass
+
+        with open(filename) as f:
+            for lineno, line in enumerate(f):
+                for regexp in checks:
+                    if regexp.search(line):
+                        print(f'{filename} line {lineno+1}: {msg}')
+                        retv = 1
+
+    return retv
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'filenames', nargs='*',
+        help='Filenames pre-commit believes are changed.',
+    )
+    parser.add_argument(
+        '--enforce-all', action='store_true',
+        help='Enforce all files are checked, not just staged files.',
+    )
+    args = parser.parse_args(argv)
+
+    return eos_test_ordereddict_usage(
+        args.filenames,
+        enforce_all=args.enforce_all,
+    )
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ exclude =
 [options.entry_points]
 console_scripts =
     eos-test-check-argument-order = eos_pre_commit_hooks.eos_test_check_argument_order:main
+    eos-test-ordereddict-usage= eos_pre_commit_hooks.eos_test_ordereddict_usage:main
 
 [bdist_wheel]
 universal = True


### PR DESCRIPTION
As discussed in https://github.com/eos/eos/issues/1016, based on a few previous instances of use by Danny.

`pyupgrade` doesn't (and won't) do this as there are still valid instances where `OrderedDict`s are correct, see the discussion in https://github.com/asottile/pyupgrade/issues/99.
So I just knocked up a quick regexp solution. 