### PR TITLE
Fix hook and add check

### DIFF
--- a/.github/workflows/validate-manifest.yaml
+++ b/.github/workflows/validate-manifest.yaml
@@ -1,0 +1,18 @@
+on:
+  pull_request:
+    branches:
+      - master
+
+name: Check if pre-commit manifest is valid
+
+jobs:
+  pre-commit-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13.7"
+      - run: python -m pip install pre-commit
+      - run: pre-commit validate-manifest .pre-commit-hooks.yaml
+

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,6 +8,8 @@
     name: 'EOS: OrderedDict usage'
     description: Checks if OrderedDict is imported, as it likely isn't needed
     entry: eos-test-ordereddict-usage
+    language: python
+    types: [text]
 -   id: eos-test-check-references
     name: 'EOS: Check EOS references'
     description: Checks if references mentioned in the EOS source code are well formed and appear in the references.yaml file


### PR DESCRIPTION
The `language` and `type` metadata for the OrderedDict hook was "stolen" by the check-references hook in #4, so currently these pre-commits can't be used. I noticed this when testing at some point, but forgot to push the fixed commit to my branch.
To avoid this particular error, I've added a workflow which uses the `pre-commit` command `validate-manifest` to check this file at least.